### PR TITLE
Update asn1.c

### DIFF
--- a/asn1.c
+++ b/asn1.c
@@ -164,7 +164,7 @@ int asn1_dec_long(const char *b, int *i, int l, long long *val) {
     long long res = 0;
 
     for (int j = 0; j < n; j++) {
-        res = res << 8 | b[(*i)++];
+        res = res << 8 | (unsigned char)b[(*i)++];
     }
 
     if (val) {


### PR DESCRIPTION
as b is considered signed char,  it will screw the resulting value when byte value will be > 127.
Casting to unsigned fixes the problem